### PR TITLE
Fix overlapped key detection for debug keys (F3+Key)

### DIFF
--- a/src/main/java/com/sakuraryoko/vkm/keybind/KeybindUtil.java
+++ b/src/main/java/com/sakuraryoko/vkm/keybind/KeybindUtil.java
@@ -187,4 +187,17 @@ public class KeybindUtil
 
         return "["+cat+keybind.getTranslatedCategory()+"§r] ("+id+keybind.getTranslatedId()+"§r)";
     }
+
+    public static int getDebugModifierKeyCode()
+    {
+        KeyMapping keyBinding = getByIdVanilla("key.debug.modifier");
+
+        if (keyBinding == null)
+        {
+            return -1;
+        }
+
+        InputConstants.Key key = keyBinding.key;
+        return key.getValue();
+    }
 }

--- a/src/main/java/com/sakuraryoko/vkm/keybind/KeybindUtil.java
+++ b/src/main/java/com/sakuraryoko/vkm/keybind/KeybindUtil.java
@@ -190,14 +190,18 @@ public class KeybindUtil
 
     public static int getDebugModifierKeyCode()
     {
-        KeyMapping keyBinding = getByIdVanilla("key.debug.modifier");
+        //#if MC >= 1.21.11
+        //$$ KeyMapping keyBinding = getByIdVanilla("key.debug.modifier");
 
-        if (keyBinding == null)
-        {
-            return -1;
-        }
+        //$$ if (keyBinding == null)
+        //$$ {
+            //$$ return -1;
+        //$$ }
 
-        InputConstants.Key key = keyBinding.key;
-        return key.getValue();
+        //$$ InputConstants.Key key = keyBinding.key;
+        //$$ return key.getValue();
+        //#else
+        return -1;
+        //#endif
     }
 }

--- a/src/main/java/com/sakuraryoko/vkm/keybind/KeybindVanilla.java
+++ b/src/main/java/com/sakuraryoko/vkm/keybind/KeybindVanilla.java
@@ -170,8 +170,12 @@ public class KeybindVanilla implements IKeybind
 
     private boolean isDebugKey()
     {
-        String id = this.keybind.getId();
-        return id.startsWith("key.debug.") && !id.equals("key.debug.modifier") && !id.equals("key.debug.overlay");
+        //#if MC >= 1.21.11
+        //$$ String id = this.keybind.getId();
+        //$$ return id.startsWith("key.debug.") && !id.equals("key.debug.modifier") && !id.equals("key.debug.overlay");
+        //#else
+        return false;
+        //#endif
     }
 
     @Override

--- a/src/main/java/com/sakuraryoko/vkm/keybind/KeybindVanilla.java
+++ b/src/main/java/com/sakuraryoko/vkm/keybind/KeybindVanilla.java
@@ -168,6 +168,12 @@ public class KeybindVanilla implements IKeybind
         return this.keybind.matchesKey(keyCode, -1) || this.keybind.matchesMouse(keyCode);
     }
 
+    private boolean isDebugKey()
+    {
+        String id = this.keybind.getId();
+        return id.startsWith("key.debug.") && !id.equals("key.debug.modifier") && !id.equals("key.debug.overlay");
+    }
+
     @Override
     public boolean overlaps(IKeybind other)
     {
@@ -189,7 +195,11 @@ public class KeybindVanilla implements IKeybind
                 return false;
             }
 
-            return kbv.keybind.matchesKey(keyCode, -1) || kbv.keybind.matchesMouse(keyCode);
+            // If both are normal keys, or both are debug keys, we can just compare the base key code.
+            if (this.isDebugKey() == kbv.isDebugKey())
+            {
+                return kbv.keybind.matchesKey(keyCode, -1) || kbv.keybind.matchesMouse(keyCode);
+            }
         }
 
         // Cloned from KeybindMulti to have similar behavior.
@@ -266,6 +276,16 @@ public class KeybindVanilla implements IKeybind
     public List<Integer> getKeys()
     {
         List<Integer> list = new ArrayList<>();
+
+        if (this.isDebugKey())
+        {
+            int modCode = KeybindUtil.getDebugModifierKeyCode();
+
+            if (modCode != -1)
+            {
+                list.add(modCode);
+            }
+        }
 
         list.add(this.getKeyCode());
 


### PR DESCRIPTION
### Summary
This PR fixes an issue where Vanilla debug keybinds (e.g., `F3 + B` for Hitboxes) were incorrectly identified as conflicting with standard single-key bindings (e.g., `B` for Backpack) in newer Minecraft versions (1.21+).

Fix #7 